### PR TITLE
Add default option to raw input

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ To allow the user to pick many options for a single question, invoke `questionna
 
 
 ### Raw Input
-For raw input, invoke `questionnaire.raw`. Optionally pass a `type` (`int`, `float`, ...) to coerce the answer to a given type. By default, the user can go back from a raw input question by entering `<` as the answer. To change this, pass your own `go_back` string.
+For raw input, invoke `questionnaire.raw`. Optionally pass a `type` (`int`, `float`, ...) to coerce the answer to a given type. You can also pass a `default` value to be inserted if the user does not write anything. By default, the user can go back from a raw input question by entering `<` as the answer. To change this, pass your own `go_back` string.
 
 If you want to capture password input, or any other secret input, pass `secret=True`.
 
@@ -184,7 +184,7 @@ __The prompter API is super simple__: a prompter is a function that should displ
 
 
 ### Going Back
-If you want your prompter to allow users to go back, simply raise a `QuestionnaireGoBack` exception in the body of your prompter function instead of returning the answer. This exception can imported like so: `from questionnaire.prompters import QuestionnaireGoBack`. 
+If you want your prompter to allow users to go back, simply raise a `QuestionnaireGoBack` exception in the body of your prompter function instead of returning the answer. This exception can imported like so: `from questionnaire.prompters import QuestionnaireGoBack`.
 
 When you raise this exception in your prompter, you can pass the __number of steps to go back__ into the exception's constructor. For example, `raise QuestionnaireGoBack(2)` will go back two questions. If no value is passed to the constructor, the user goes back one question.
 

--- a/examples/colors.py
+++ b/examples/colors.py
@@ -1,0 +1,8 @@
+from questionnaire import Questionnaire
+import requests
+
+q = Questionnaire(show_answers=False, can_go_back=False)
+q.raw('color', prompt='Favorite color (type ENTER to insert the default value):', default='blue')
+
+q.run()
+print(q.answers.get('color'))

--- a/questionnaire/__init__.py
+++ b/questionnaire/__init__.py
@@ -77,7 +77,7 @@ class Question:
         self._validate = None
         self._transform = None
         self.assign_prompter(kwargs.pop('prompter'))  # `prompter` required
-        self.assign_prompt(kwargs.pop('prompt', None))  # `prompt` optional
+        self.assign_prompt(kwargs.pop('prompt', None), kwargs.get('default', None))  # `prompt` optional, `default` optional
         self.prompter_args = args
         self.prompter_kwargs = kwargs
 
@@ -93,8 +93,10 @@ class Question:
         else:
             self.prompter = prompter
 
-    def assign_prompt(self, prompt):
+    def assign_prompt(self, prompt, default=None):
         self.prompt = prompt.strip() + ' ' if prompt else '{}: '.format(self.key)
+        if default is not None:
+            self.prompt += '[{}] '.format(default)
 
     def condition(self, *args):
         self._condition = Condition(*args)

--- a/questionnaire/prompters.py
+++ b/questionnaire/prompters.py
@@ -125,6 +125,7 @@ def raw(prompt, *args, **kwargs):
     """
     go_back = kwargs.get('go_back', '<')
     type_ = kwargs.get('type', str)
+    default = kwargs.get('default', '')
     with stdout_redirected(sys.stderr):
         while True:
             try:
@@ -134,6 +135,9 @@ def raw(prompt, *args, **kwargs):
                     answer = raw_input(prompt)
                 else:
                     answer = input(prompt)
+
+                if not answer:
+                    answer = default
 
                 if answer == go_back:
                     raise QuestionnaireGoBack


### PR DESCRIPTION
Allows to set a default value for raw inputs.
Default value is used if the user does not insert any value, just pressing Enter.

Usable with: `
q.raw('key', prompt='Prompt (type ENTER to insert the default value):', default='default_value')`